### PR TITLE
Add CfP end date and format the CfP section

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,16 +7,29 @@ layout: default
 
 ## {{ site.description }}
 
-For years we’ve dreamed about creating a conference for Open Source app developers. There are conferences for the people already on the inside—the people building the platforms and big first-party apps, but what we really want is to create a space to bring in the people on the outside and include them in the process. This conference is our way of reaching out to app developers, sharing the knowledge we’ve collected over the years, and giving you a space to ask questions and provide feedback.
+For years we've dreamed about creating a conference for open source app developers. There are conferences for the people already on the inside—the ones building platforms and big first-party apps, but we're bringing in those on the outside to include them in the process. This conference is our way of reaching out to app developers, sharing the knowledge we've all collected over the years, and providing a space to ask questions and provide feedback.
 
-We’re excited to invite you to the first **elementary Developer Weekend** 🎉️
+We're excited to invite you to the first **elementary Developer Weekend** 🎉️
 
 ### Call for Papers
 
-We need your help to make this conference a reality and we’re now taking submissions for your presentation concepts. Topics should be primarily educational, focused on design, engineering, or entrepreneurship, and can range in target audience from those seeking to build their first app to experienced developers looking to take their apps to the next level. This is your opportunity to share your expertise with the community.
+We need your help to make this conference a reality! **The call for papers is now open through April 20, 2021.** We are accepting both Ideas and Talks:
+
+- **Ideas** are concepts for talks you'd like to hear or think would be beneficial to the community, but that you are not necessarily committed to giving yourself.
+
+- **Talks** are proposals for presentations that you would like to give; these should be well thought out and you should be committed to preparing and recording a talk, as well as being present during the conference for any Q&A.
+
+Topics should: 
+
+- Be primarily educational
+- Focus on design, engineering, or entrepreneurship
+- Target an audience anywhere from those seeking to build their first app to experienced developers looking to take their apps to the next level
+
+This is your opportunity to share your expertise with the community.
 
 <div style="text-align: center" markdown="1">
-[Submit a Presentation Concept →](https://github.com/elementary/edw/discussions/categories/talk-proposals){: .button }
+[Suggest an Idea →](https://github.com/elementary/edw/discussions/categories/ideas)
+[Submit a Talk →](https://github.com/elementary/edw/discussions/categories/talk-proposals){: .button }
 </div>
 
 The format will be pre-recorded presentations streamed online, with optional live Q&A following. More details about the format and how to record and submit your presentation will be shared soon.

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -19,10 +19,11 @@
 
 html {
   background: rgb(var(--background-color));
-  color: rgb(var(--primary-color));
+  color: rgb(var(--text-color));
   display: flex;
   font-family: Inter, sans-serif;
   font-size: 16px;
+  line-height: 1.5em;
   min-height: 100%;
 }
 
@@ -46,24 +47,27 @@ h1 {
 }
 
 h2 {
+  color: rgb(var(--primary-color));
   font-size: 2em;
   font-weight: 300;
-  margin: 0.5em 0 2em;
+  margin: 0.25em 0 2em;
   text-align: center;
 }
 
 h3 {
+  color: rgb(var(--primary-color));
   font-size: 1.5em;
   font-weight: 400;
-}
-
-p {
-  color: rgb(var(--text-color));
-  line-height: 1.5em;
+  margin: 2em auto 0;
 }
 
 a {
   color: rgb(var(--primary-color));
+  text-decoration: none;
+  
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .button {
@@ -71,10 +75,9 @@ a {
   border-radius: 0.25em;
   color: rgb(var(--background-color));
   display: inline-block;
-  margin: 2em 1em;
+  margin: 1.5em 1em;
   opacity: 0.8;
-  padding: 1em;
-  text-decoration: none;
+  padding: 0.5em 0.75em;
   transition: all 150ms ease;
 
   &:hover {


### PR DESCRIPTION
- Tightened up some leading copy
- Added the CfP close date
- Broke the paragraph about talks into bullet points to more clearly communicate it
- Added an explicit link to submit ideas
- Fixed some weird styling leftover from when it was just a teaser logo

Fixes https://github.com/elementary/edw-planning/issues/30

![Screenshot from 2021-03-22 14-58-16](https://user-images.githubusercontent.com/611168/112057562-122b3280-8b1f-11eb-80a3-2d3686166434.png)

![Screenshot from 2021-03-22 14-58-20](https://user-images.githubusercontent.com/611168/112057567-12c3c900-8b1f-11eb-9aa9-c7eeb55e19e4.png)
