### PR TITLE
Landing page: add schedule

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,11 +11,11 @@ For years we've dreamed about creating a conference for open source app develope
 
 We're excited to invite you to the first **elementary Developer Weekend** 🎉️
 
-### Merch & Sponsors
+## Merch & Sponsors
 
 We've launched a **limited run** of edw merch on [our store][store]; check it out now to get your tee or stickers in time for edw on June 26!
 
-#### Become a Sponsor
+### Become a Sponsor
 
 Help support us and our developer ecosystem by becoming a sponsor of edw. We've introduced one-time tiers on [GitHub Sponsors][sponsors] that include an **exclusive store coupon** and your name listed as a sponsor of edw.
 
@@ -24,5 +24,51 @@ Help support us and our developer ecosystem by becoming a sponsor of edw. We've 
 [Become a Sponsor][sponsors]{: .button }
 </div>
 
+## Schedule & Program
+
+edw will be online June 26–27 on the [elementary YouTube channel][youtube] with contributors available for discussion in the live chat. Talks will include:
+
+### Saturday, June 26
+
+#### 2021 State of the Platform _by Daniel Foré_
+
+A high level overview of the AppCenter platform and major advancements from the past year. We'll cover developer tools, new APIs, and some stats about the growth of our audience. Plus, some commentary on next steps.
+
+#### Akira: Building a UX App From Scratch _by Alessandro Castellani_
+
+An overview of the initial struggles and motivations behind the launching of Akira, followed by a quick analysis of the stack currently used, the state of the app, and future plans.
+
+#### Making an Accessible App _by Anna E. Cook_
+
+With digital products becoming increasingly integral to our lives, how can designers and developers make sure our work is inclusive to disabled people? In this session, we will talk about how accessibility creates amazing products, applications, and experiences as well as the basic considerations of accessibility both in design and code. Learn the basics about accessibility laws, guidelines, and best practices so you can make your work even better!
+
+
+#### Improving App Development in Vala _by Princeton Ferro_
+
+A look into the ongoing work behind the scenes to further improve the Vala developer experience, from work on the Vala Language Server to integrating this work in IDEs and with build systems, to internal improvements in the Vala compiler.
+
+### Sunday, June 27
+
+#### How to Contribute to elementary OS _by Igor Montagner_
+
+A look behind the scenes from the point of view of a new contributor to elementary OS. This talk covers both technical and personal experiences when contributing to elementary OS to show how you can get involved.
+
+#### The Importance of Defaults _by Ravish Malik_
+
+Learn how crucial the default out-of-the-box experience is to a user, the elementary Human Interface Guidelines around Accessible Configuration, and how the default experience must give the user what they need before taking them on a journey where they can find complexity and advancement at their own pace.
+
+#### My First AppCenter App _by Justin Campbel_
+
+Hear from a web developer with experience in React and Python as they build an app for elementary OS and AppCenter to get familiar with the workflow and tooling—plus, hear about their day-to-day usage of elementary OS as a visually impaired developer. This talk covers the process of writing, submitting, and maintaining an app for elementary OS.
+
+#### Creating Compelling App Icons _by Micah Ilbery_
+
+Learn how to make good app icons and why a good app icon is important. Plus, a brief walk-through of the elementary Human Interface Guidelines surrounding icons, and a demonstration of how to use the these guidelines to make an icon.
+
+#### GTK for Web Developers _by Darshak Parikh_
+
+Bridge your web development know-how to the desktop world. This talk draws parallels between CSS Grid and Gtk.Grid, DOM tree and Gtk.Window hierarchy, web inspectors and GTK Inspector, web CSS and GtkCSS, and (loosely) reactive components and Gtk.Widget.
+
 [store]: https://store.elementary.io/#elementary-developer-weekend
 [sponsors]: https://github.com/sponsors/elementary?frequency=one-time
+[youtube]: https://www.youtube.com/elementaryinc

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -51,24 +51,34 @@ h2 {
   font-size: 2em;
   font-weight: 300;
   line-height: 1.25em;
+  margin: 2em auto 0;
+}
+
+h1 + h2 {
   margin: 0.25em 0 2em;
   text-align: center;
 }
 
 h3 {
   color: rgb(var(--primary-color));
-  font-size: 1.5em;
+  font-size: 1.4em;
   font-weight: 400;
+  margin: 1.67em auto 0;
+}
+
+h4 {
+  font-size: 1.125em;
+  font-weight: 600;
   margin: 2em auto 0;
+
+  em {
+    font-style: normal;
+    font-weight: 400;
+  }
 }
 
 a {
   color: rgb(var(--primary-color));
-  text-decoration: none;
-  
-  &:hover {
-    text-decoration: underline;
-  }
 }
 
 .button {
@@ -79,6 +89,7 @@ a {
   margin: 1.5em 1em;
   opacity: 0.8;
   padding: 0.5em 0.75em;
+  text-decoration: none;
   transition: all 150ms ease;
 
   &:hover {


### PR DESCRIPTION
Fixes #56

Should get a double-check from @danrabbit to see if that order and split between the days makes sense. My general thoughts:

- Open with State of the Platform
- State of the Platform will probably be longer than others, so have the extra talk on the second day
- Opening day should be a variety of interesting talks:
  - Specific case study (Akira)
  - UX/a11y talk (Accessible App)
  - a more developer-oriented talk (Vala)
- Second day should open with pretty broad interest talk (How to Contribute), but then dive into a variety of topics to keep people engaged: 
  - UX (Defaults), 
  - case study (My First App), 
  - design (App Icons), and 
  - development (GTK for Web Devs)

Super open to rejigging anything though, this was just how it sort of fell together when I played with splitting them up between the days.

I also coped talk abstracts from the Discussions, and edited/re-wrote where needed. Open to tweaking on those as needed.